### PR TITLE
Add atomic inbox-dump notes for learning, workflow, and job-search systems

### DIFF
--- a/01_STAGING/00_INBOX_DUMP/ATOMIC_NOTES/Constraint - Monthly Audiobook Capacity.md
+++ b/01_STAGING/00_INBOX_DUMP/ATOMIC_NOTES/Constraint - Monthly Audiobook Capacity.md
@@ -1,0 +1,22 @@
+# Constraint - Monthly Audiobook Capacity
+
+Type: Constraint
+Tags: #learning #audiobooks #capacity-planning
+
+## Core idea
+Learning input is constrained to 15 listening hours per month for a 5-month period.
+
+## Explanation
+The plan explicitly sets a hard monthly cap and a finite program horizon. This turns learning from an open-ended aspiration into a bounded execution system.
+
+## Use case
+Use as a planning constraint when selecting books, pacing learning blocks, and preventing content overload.
+
+## Links
+- Connects to [[Plan - Five Month Audiobook Curriculum]]
+- Connects to [[Decision - Sequential Listening Rule]]
+- Connects to [[Heuristic - Behavior Change Filter for Learning Inputs]]
+
+## Questions
+- Is 15 hours realistic given weekly schedule variability?
+- Should missed hours roll forward or expire each month?

--- a/01_STAGING/00_INBOX_DUMP/ATOMIC_NOTES/Decision - Distraction Capture Instead of Distraction Obedience.md
+++ b/01_STAGING/00_INBOX_DUMP/ATOMIC_NOTES/Decision - Distraction Capture Instead of Distraction Obedience.md
@@ -1,0 +1,25 @@
+# Decision - Distraction Capture Instead of Distraction Obedience
+
+Type: Decision
+Tags: #attention #distraction #decision-hygiene
+
+## Core idea
+When distraction appears, capture it (notebook/chat dump) and return immediately to current microtask.
+
+## Explanation
+The method separates cognitive offloading from context switching. It preserves focus while retaining potentially useful thoughts for later triage.
+
+## Use case
+Use during any deep work block to prevent derailment without suppressing thoughts.
+
+## Links
+- Connects to [[Workflow - Micro Execution OS for Deep Work Blocks]]
+- Overlaps with [[Heuristic - Behavior Change Filter for Learning Inputs]]
+
+## Questions
+- Which capture method yields fastest return-to-task?
+- How often should captured items be reviewed?
+
+## Model layer (relevant)
+- Behavioral: urge surfing + delayed gratification.
+- Decision: defer low-value choice until scheduled review window.

--- a/01_STAGING/00_INBOX_DUMP/ATOMIC_NOTES/Decision - Sequential Listening Rule.md
+++ b/01_STAGING/00_INBOX_DUMP/ATOMIC_NOTES/Decision - Sequential Listening Rule.md
@@ -1,0 +1,25 @@
+# Decision - Sequential Listening Rule
+
+Type: Decision
+Tags: #learning #focus #decision
+
+## Core idea
+Only one primary audiobook is active at a time; secondary audio is optional only if time remains.
+
+## Explanation
+No parallel listening reduces context switching and pseudo-progress. The rule is designed to increase depth, retention, and behavioral transfer.
+
+## Use case
+Apply whenever adding new learning inputs; reject concurrent books by default.
+
+## Links
+- Connects to [[Constraint - Monthly Audiobook Capacity]]
+- Overlaps with [[Workflow - Micro Execution OS for Deep Work Blocks]] (single-tasking principle)
+
+## Questions
+- What explicit condition triggers secondary-book eligibility?
+- Should this rule apply to podcasts/courses too?
+
+## Model layer (relevant)
+- Behavioral: commitment device against novelty-seeking.
+- Decision: pre-commitment rule that lowers in-the-moment choice friction.

--- a/01_STAGING/00_INBOX_DUMP/ATOMIC_NOTES/Heuristic - Behavior Change Filter for Learning Inputs.md
+++ b/01_STAGING/00_INBOX_DUMP/ATOMIC_NOTES/Heuristic - Behavior Change Filter for Learning Inputs.md
@@ -1,0 +1,26 @@
+# Heuristic - Behavior Change Filter for Learning Inputs
+
+Type: Heuristic
+Tags: #learning #behavior-change #quality-filter
+
+## Core idea
+A learning input is valid only if it changes behavior; if no behavior changes, stop consuming it.
+
+## Explanation
+Post-session reflection is constrained to one sentence: “This changes my behavior by ___.” This creates a direct conversion test from information to action.
+
+## Use case
+Use after reading/listening sessions to prune low-yield content and strengthen implementation discipline.
+
+## Links
+- Connects to [[Decision - Sequential Listening Rule]]
+- Connects to [[Workflow - Micro Execution OS for Deep Work Blocks]]
+- Overlaps with [[Decision - Distraction Capture Instead of Distraction Obedience]]
+
+## Questions
+- How long should a book be given before declaring “no behavior change”?
+- Should behavior-change evidence be logged weekly?
+
+## Model layer (relevant)
+- RL: reward signal tied to behavior delta, not content volume.
+- Systems: output metric replaces input metric.

--- a/01_STAGING/00_INBOX_DUMP/ATOMIC_NOTES/INDEX.md
+++ b/01_STAGING/00_INBOX_DUMP/ATOMIC_NOTES/INDEX.md
@@ -1,0 +1,25 @@
+# Inbox Dump — Atomic Notes Index
+
+## Source coverage
+- Processed source notes from `00_INBOX_DUMP/` into atomic notes without deleting originals.
+
+## Atomic notes
+- [[Constraint - Monthly Audiobook Capacity]]
+- [[Decision - Sequential Listening Rule]]
+- [[Plan - Five Month Audiobook Curriculum]]
+- [[Heuristic - Behavior Change Filter for Learning Inputs]]
+- [[Task System - High Impact Job Search Daily Actions]]
+- [[Task System - Supporting Operations and Organization]]
+- [[Workflow - Micro Execution OS for Deep Work Blocks]]
+- [[Decision - Distraction Capture Instead of Distraction Obedience]]
+- [[Open Loop - Movies Note Needs Clarification]]
+- [[Open Loop - Job Sites List Is Empty]]
+- [[Open Loop - Sticknote Password Note Is Empty]]
+
+## Suggested hubs
+- [[Learning Operating System]]
+- [[Job Search System]]
+- [[Attention Management]]
+- [[Second Brain Processing Pipeline]]
+
+#inbox-processing #atomic-notes #second-brain

--- a/01_STAGING/00_INBOX_DUMP/ATOMIC_NOTES/Open Loop - Job Sites List Is Empty.md
+++ b/01_STAGING/00_INBOX_DUMP/ATOMIC_NOTES/Open Loop - Job Sites List Is Empty.md
@@ -1,0 +1,20 @@
+# Open Loop - Job Sites List Is Empty
+
+Type: Open Question
+Tags: #job-search #inbox #clarification-needed
+
+## Core idea
+The “job sites” note currently has no content and should be populated or archived.
+
+## Explanation
+An empty placeholder increases cognitive noise if it persists without a defined next action.
+
+## Use case
+Resolve during next planning session by either adding canonical job boards or deleting the placeholder.
+
+## Links
+- Connects to [[Task System - High Impact Job Search Daily Actions]]
+
+## Questions
+- Which job sites are primary channels vs optional?
+- Should this become a reusable shortlist template?

--- a/01_STAGING/00_INBOX_DUMP/ATOMIC_NOTES/Open Loop - Movies Note Needs Clarification.md
+++ b/01_STAGING/00_INBOX_DUMP/ATOMIC_NOTES/Open Loop - Movies Note Needs Clarification.md
@@ -1,0 +1,20 @@
+# Open Loop - Movies Note Needs Clarification
+
+Type: Open Question
+Tags: #inbox #movies #clarification-needed
+
+## Core idea
+The note contains only “The ultimate life,” which is too ambiguous to classify confidently.
+
+## Explanation
+It may refer to a movie title, a theme, or a reminder. Ambiguity reduces retrievability and actionability.
+
+## Use case
+Use as a prompt for clarification during weekly inbox processing.
+
+## Links
+- Connects to [[Second Brain Processing Pipeline]]
+
+## Questions
+- Is “The ultimate life” a movie to watch, a note title, or a concept?
+- If it is a movie, what platform/source and why it matters?

--- a/01_STAGING/00_INBOX_DUMP/ATOMIC_NOTES/Open Loop - Sticknote Password Note Is Empty.md
+++ b/01_STAGING/00_INBOX_DUMP/ATOMIC_NOTES/Open Loop - Sticknote Password Note Is Empty.md
@@ -1,0 +1,23 @@
+# Open Loop - Sticknote Password Note Is Empty
+
+Type: Risk / Open Question
+Tags: #security #inbox #clarification-needed
+
+## Core idea
+The “sticknote_password” note is empty; if this indicates credential handling intent, it requires secure-system handling.
+
+## Explanation
+Password-related placeholders should be either moved to a secure password manager workflow or removed to prevent insecure habits.
+
+## Use case
+Use as a trigger to formalize credential management policy.
+
+## Links
+- Connects to [[Second Brain Processing Pipeline]]
+
+## Questions
+- Was a password intended to be stored here?
+- Is there an approved password manager and process?
+
+## Model layer (relevant)
+- Systems: security hygiene via standardized storage boundary.

--- a/01_STAGING/00_INBOX_DUMP/ATOMIC_NOTES/Plan - Five Month Audiobook Curriculum.md
+++ b/01_STAGING/00_INBOX_DUMP/ATOMIC_NOTES/Plan - Five Month Audiobook Curriculum.md
@@ -1,0 +1,27 @@
+# Plan - Five Month Audiobook Curriculum
+
+Type: Plan
+Tags: #learning-plan #audiobooks #curriculum
+
+## Core idea
+A 5-month curriculum is organized by capability themes: focus, thinking, biology, power/communication, identity.
+
+## Explanation
+The sequence appears intentional: foundational attention first, then decision quality, then physiological stability, then social leverage, then self-image integration.
+
+## Use case
+Use as a prebuilt roadmap for monthly learning execution and review checkpoints.
+
+## Links
+- Connects to [[Constraint - Monthly Audiobook Capacity]]
+- Connects to [[Heuristic - Behavior Change Filter for Learning Inputs]]
+- This connects to [[Task System - High Impact Job Search Daily Actions]] by improving execution quality
+
+## Questions
+- What monthly review criteria determine successful completion?
+- Which month has highest likely implementation friction?
+
+## Extracted facts
+- Program length: 5 months.
+- Monthly themes and selected books are predefined.
+- Month 1 starts with Deep Work as mandatory first item.

--- a/01_STAGING/00_INBOX_DUMP/ATOMIC_NOTES/Task System - High Impact Job Search Daily Actions.md
+++ b/01_STAGING/00_INBOX_DUMP/ATOMIC_NOTES/Task System - High Impact Job Search Daily Actions.md
@@ -1,0 +1,29 @@
+# Task System - High Impact Job Search Daily Actions
+
+Type: Task System
+Tags: #job-search #execution #high-impact
+
+## Core idea
+Prioritize direct outcome-producing actions daily: applications, referrals, technical practice, and public proof-of-work.
+
+## Explanation
+The high-impact list centers on measurable leverage points (targeted applications, networking outreach, technical skill reps, visible project sharing).
+
+## Use case
+Use as daily default checklist before any organizational/cleanup tasks.
+
+## Links
+- Connects to [[Task System - Supporting Operations and Organization]]
+- Connects to [[Workflow - Micro Execution OS for Deep Work Blocks]]
+
+## Questions
+- Which 2-3 actions are minimum viable daily non-negotiables?
+- What metric defines “targeted” in job applications?
+
+## Extracted tasks
+- Apply for 10 targeted jobs and log them.
+- Message 5 LinkedIn contacts for referrals.
+- Do 1 LeetCode end-to-end.
+- Process 1 system design video with trade-off notes.
+- Complete 1 module + small code demo.
+- Post latest GitHub project on LinkedIn.

--- a/01_STAGING/00_INBOX_DUMP/ATOMIC_NOTES/Task System - Supporting Operations and Organization.md
+++ b/01_STAGING/00_INBOX_DUMP/ATOMIC_NOTES/Task System - Supporting Operations and Organization.md
@@ -1,0 +1,25 @@
+# Task System - Supporting Operations and Organization
+
+Type: Support System
+Tags: #operations #organization #maintenance
+
+## Core idea
+Use low-impact tasks to maintain infrastructure, but keep them subordinate to high-impact execution work.
+
+## Explanation
+Items like Notion cleanup, folder organization, and vault restructuring are useful enablers but can become avoidance if not bounded.
+
+## Use case
+Schedule in protected low-energy blocks or after completion of high-impact daily quota.
+
+## Links
+- Connects to [[Task System - High Impact Job Search Daily Actions]]
+- Overlaps with [[Decision - Distraction Capture Instead of Distraction Obedience]]
+
+## Questions
+- What weekly time cap should be set for support tasks?
+- Which support tasks can be automated or templated?
+
+## Model layer (relevant)
+- Systems: distinguish throughput drivers from maintenance overhead.
+- Decision: priority ladder prevents optimization-before-output.

--- a/01_STAGING/00_INBOX_DUMP/ATOMIC_NOTES/Workflow - Micro Execution OS for Deep Work Blocks.md
+++ b/01_STAGING/00_INBOX_DUMP/ATOMIC_NOTES/Workflow - Micro Execution OS for Deep Work Blocks.md
@@ -1,0 +1,27 @@
+# Workflow - Micro Execution OS for Deep Work Blocks
+
+Type: Workflow
+Tags: #deep-work #workflow #execution-system
+
+## Core idea
+Convert large tasks into 20–30 minute microtasks, execute one microtask per focused block, then log reality and iterate.
+
+## Explanation
+The workflow integrates planning, execution timer, break cycle, and feedback correction. Tools (Super Productivity + Forest) support but do not replace the protocol.
+
+## Use case
+Apply to any cognitively heavy goal (LeetCode, job applications, interview prep, project work).
+
+## Links
+- Connects to [[Decision - Sequential Listening Rule]] (single-thread focus)
+- Connects to [[Task System - High Impact Job Search Daily Actions]]
+- Connects to [[Decision - Distraction Capture Instead of Distraction Obedience]]
+
+## Questions
+- What criteria decide whether a microtask was sized correctly?
+- What is the daily/weekly cadence for protocol review?
+
+## Model layer (relevant)
+- Behavioral: implementation intention + friction reduction.
+- RL: short-loop feedback updates task sizing policy.
+- Systems: closed-loop control (plan → execute → log → adjust).


### PR DESCRIPTION
### Motivation
- Convert inbox material into atomic, actionable notes to seed a learning operating system and execution-focused workflows.
- Surface constraints, decisions, heuristics, plans, task systems, and open loops to reduce cognitive overhead and guide daily execution.
- Create explicit links and metadata across notes to support routable processing and review.

### Description
- Add a new `01_STAGING/00_INBOX_DUMP/ATOMIC_NOTES/` index file and multiple atomic note markdown files including `Constraint - Monthly Audiobook Capacity.md`, `Decision - Distraction Capture Instead of Distraction Obedience.md`, `Decision - Sequential Listening Rule.md`, `Heuristic - Behavior Change Filter for Learning Inputs.md`, `Plan - Five Month Audiobook Curriculum.md`, `Workflow - Micro Execution OS for Deep Work Blocks.md`, `Task System - High Impact Job Search Daily Actions.md`, `Task System - Supporting Operations and Organization.md`, and several `Open Loop` notes for inbox cleanup.
- Each note includes `Type` and `Tags`, a concise core idea, explanation, use case, inter-note `Links`, questions for clarification, and occasional `Model layer` or `Extracted facts` metadata.
- Cross-linking between notes was added to connect constraints, plans, workflows, heuristics, and task systems.
- Files are added as content-only additions under `01_STAGING/00_INBOX_DUMP/ATOMIC_NOTES/` to preserve original inbox sources.

### Testing
- No automated tests were executed because this is a content-only addition of markdown notes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f51953a30883268eed79e4b1e7624c)