### PR TITLE
Add atomic inbox notes and processing audit

### DIFF
--- a/01_STAGING/00_INBOX_DUMP/ATOMIC_NOTES/Constraint - Monthly Audiobook Capacity.md
+++ b/01_STAGING/00_INBOX_DUMP/ATOMIC_NOTES/Constraint - Monthly Audiobook Capacity.md
@@ -1,0 +1,22 @@
+# Constraint - Monthly Audiobook Capacity
+
+Type: Constraint
+Tags: #learning #audiobooks #capacity-planning
+
+## Core idea
+Learning input is constrained to 15 listening hours per month for a 5-month period.
+
+## Explanation
+The plan explicitly sets a hard monthly cap and a finite program horizon. This turns learning from an open-ended aspiration into a bounded execution system.
+
+## Use case
+Use as a planning constraint when selecting books, pacing learning blocks, and preventing content overload.
+
+## Links
+- Connects to [[Plan - Five Month Audiobook Curriculum]]
+- Connects to [[Decision - Sequential Listening Rule]]
+- Connects to [[Heuristic - Behavior Change Filter for Learning Inputs]]
+
+## Questions
+- Is 15 hours realistic given weekly schedule variability?
+- Should missed hours roll forward or expire each month?

--- a/01_STAGING/00_INBOX_DUMP/ATOMIC_NOTES/Decision - Distraction Capture Instead of Distraction Obedience.md
+++ b/01_STAGING/00_INBOX_DUMP/ATOMIC_NOTES/Decision - Distraction Capture Instead of Distraction Obedience.md
@@ -1,0 +1,25 @@
+# Decision - Distraction Capture Instead of Distraction Obedience
+
+Type: Decision
+Tags: #attention #distraction #decision-hygiene
+
+## Core idea
+When distraction appears, capture it (notebook/chat dump) and return immediately to current microtask.
+
+## Explanation
+The method separates cognitive offloading from context switching. It preserves focus while retaining potentially useful thoughts for later triage.
+
+## Use case
+Use during any deep work block to prevent derailment without suppressing thoughts.
+
+## Links
+- Connects to [[Workflow - Micro Execution OS for Deep Work Blocks]]
+- Overlaps with [[Heuristic - Behavior Change Filter for Learning Inputs]]
+
+## Questions
+- Which capture method yields fastest return-to-task?
+- How often should captured items be reviewed?
+
+## Model layer (relevant)
+- Behavioral: urge surfing + delayed gratification.
+- Decision: defer low-value choice until scheduled review window.

--- a/01_STAGING/00_INBOX_DUMP/ATOMIC_NOTES/Decision - Sequential Listening Rule.md
+++ b/01_STAGING/00_INBOX_DUMP/ATOMIC_NOTES/Decision - Sequential Listening Rule.md
@@ -1,0 +1,25 @@
+# Decision - Sequential Listening Rule
+
+Type: Decision
+Tags: #learning #focus #decision
+
+## Core idea
+Only one primary audiobook is active at a time; secondary audio is optional only if time remains.
+
+## Explanation
+No parallel listening reduces context switching and pseudo-progress. The rule is designed to increase depth, retention, and behavioral transfer.
+
+## Use case
+Apply whenever adding new learning inputs; reject concurrent books by default.
+
+## Links
+- Connects to [[Constraint - Monthly Audiobook Capacity]]
+- Overlaps with [[Workflow - Micro Execution OS for Deep Work Blocks]] (single-tasking principle)
+
+## Questions
+- What explicit condition triggers secondary-book eligibility?
+- Should this rule apply to podcasts/courses too?
+
+## Model layer (relevant)
+- Behavioral: commitment device against novelty-seeking.
+- Decision: pre-commitment rule that lowers in-the-moment choice friction.

--- a/01_STAGING/00_INBOX_DUMP/ATOMIC_NOTES/Heuristic - Behavior Change Filter for Learning Inputs.md
+++ b/01_STAGING/00_INBOX_DUMP/ATOMIC_NOTES/Heuristic - Behavior Change Filter for Learning Inputs.md
@@ -1,0 +1,26 @@
+# Heuristic - Behavior Change Filter for Learning Inputs
+
+Type: Heuristic
+Tags: #learning #behavior-change #quality-filter
+
+## Core idea
+A learning input is valid only if it changes behavior; if no behavior changes, stop consuming it.
+
+## Explanation
+Post-session reflection is constrained to one sentence: “This changes my behavior by ___.” This creates a direct conversion test from information to action.
+
+## Use case
+Use after reading/listening sessions to prune low-yield content and strengthen implementation discipline.
+
+## Links
+- Connects to [[Decision - Sequential Listening Rule]]
+- Connects to [[Workflow - Micro Execution OS for Deep Work Blocks]]
+- Overlaps with [[Decision - Distraction Capture Instead of Distraction Obedience]]
+
+## Questions
+- How long should a book be given before declaring “no behavior change”?
+- Should behavior-change evidence be logged weekly?
+
+## Model layer (relevant)
+- RL: reward signal tied to behavior delta, not content volume.
+- Systems: output metric replaces input metric.

--- a/01_STAGING/00_INBOX_DUMP/ATOMIC_NOTES/INDEX.md
+++ b/01_STAGING/00_INBOX_DUMP/ATOMIC_NOTES/INDEX.md
@@ -1,0 +1,25 @@
+# Inbox Dump — Atomic Notes Index
+
+## Source coverage
+- Processed source notes from `00_INBOX_DUMP/` into atomic notes without deleting originals.
+
+## Atomic notes
+- [[Constraint - Monthly Audiobook Capacity]]
+- [[Decision - Sequential Listening Rule]]
+- [[Plan - Five Month Audiobook Curriculum]]
+- [[Heuristic - Behavior Change Filter for Learning Inputs]]
+- [[Task System - High Impact Job Search Daily Actions]]
+- [[Task System - Supporting Operations and Organization]]
+- [[Workflow - Micro Execution OS for Deep Work Blocks]]
+- [[Decision - Distraction Capture Instead of Distraction Obedience]]
+- [[Open Loop - Movies Note Needs Clarification]]
+- [[Open Loop - Job Sites List Is Empty]]
+- [[Open Loop - Sticknote Password Note Is Empty]]
+
+## Suggested hubs
+- [[Learning Operating System]]
+- [[Job Search System]]
+- [[Attention Management]]
+- [[Second Brain Processing Pipeline]]
+
+#inbox-processing #atomic-notes #second-brain

--- a/01_STAGING/00_INBOX_DUMP/ATOMIC_NOTES/Open Loop - Job Sites List Is Empty.md
+++ b/01_STAGING/00_INBOX_DUMP/ATOMIC_NOTES/Open Loop - Job Sites List Is Empty.md
@@ -1,0 +1,20 @@
+# Open Loop - Job Sites List Is Empty
+
+Type: Open Question
+Tags: #job-search #inbox #clarification-needed
+
+## Core idea
+The “job sites” note currently has no content and should be populated or archived.
+
+## Explanation
+An empty placeholder increases cognitive noise if it persists without a defined next action.
+
+## Use case
+Resolve during next planning session by either adding canonical job boards or deleting the placeholder.
+
+## Links
+- Connects to [[Task System - High Impact Job Search Daily Actions]]
+
+## Questions
+- Which job sites are primary channels vs optional?
+- Should this become a reusable shortlist template?

--- a/01_STAGING/00_INBOX_DUMP/ATOMIC_NOTES/Open Loop - Movies Note Needs Clarification.md
+++ b/01_STAGING/00_INBOX_DUMP/ATOMIC_NOTES/Open Loop - Movies Note Needs Clarification.md
@@ -1,0 +1,20 @@
+# Open Loop - Movies Note Needs Clarification
+
+Type: Open Question
+Tags: #inbox #movies #clarification-needed
+
+## Core idea
+The note contains only “The ultimate life,” which is too ambiguous to classify confidently.
+
+## Explanation
+It may refer to a movie title, a theme, or a reminder. Ambiguity reduces retrievability and actionability.
+
+## Use case
+Use as a prompt for clarification during weekly inbox processing.
+
+## Links
+- Connects to [[Second Brain Processing Pipeline]]
+
+## Questions
+- Is “The ultimate life” a movie to watch, a note title, or a concept?
+- If it is a movie, what platform/source and why it matters?

--- a/01_STAGING/00_INBOX_DUMP/ATOMIC_NOTES/Open Loop - Sticknote Password Note Is Empty.md
+++ b/01_STAGING/00_INBOX_DUMP/ATOMIC_NOTES/Open Loop - Sticknote Password Note Is Empty.md
@@ -1,0 +1,23 @@
+# Open Loop - Sticknote Password Note Is Empty
+
+Type: Risk / Open Question
+Tags: #security #inbox #clarification-needed
+
+## Core idea
+The “sticknote_password” note is empty; if this indicates credential handling intent, it requires secure-system handling.
+
+## Explanation
+Password-related placeholders should be either moved to a secure password manager workflow or removed to prevent insecure habits.
+
+## Use case
+Use as a trigger to formalize credential management policy.
+
+## Links
+- Connects to [[Second Brain Processing Pipeline]]
+
+## Questions
+- Was a password intended to be stored here?
+- Is there an approved password manager and process?
+
+## Model layer (relevant)
+- Systems: security hygiene via standardized storage boundary.

--- a/01_STAGING/00_INBOX_DUMP/ATOMIC_NOTES/Plan - Five Month Audiobook Curriculum.md
+++ b/01_STAGING/00_INBOX_DUMP/ATOMIC_NOTES/Plan - Five Month Audiobook Curriculum.md
@@ -1,0 +1,27 @@
+# Plan - Five Month Audiobook Curriculum
+
+Type: Plan
+Tags: #learning-plan #audiobooks #curriculum
+
+## Core idea
+A 5-month curriculum is organized by capability themes: focus, thinking, biology, power/communication, identity.
+
+## Explanation
+The sequence appears intentional: foundational attention first, then decision quality, then physiological stability, then social leverage, then self-image integration.
+
+## Use case
+Use as a prebuilt roadmap for monthly learning execution and review checkpoints.
+
+## Links
+- Connects to [[Constraint - Monthly Audiobook Capacity]]
+- Connects to [[Heuristic - Behavior Change Filter for Learning Inputs]]
+- This connects to [[Task System - High Impact Job Search Daily Actions]] by improving execution quality
+
+## Questions
+- What monthly review criteria determine successful completion?
+- Which month has highest likely implementation friction?
+
+## Extracted facts
+- Program length: 5 months.
+- Monthly themes and selected books are predefined.
+- Month 1 starts with Deep Work as mandatory first item.

--- a/01_STAGING/00_INBOX_DUMP/ATOMIC_NOTES/Task System - High Impact Job Search Daily Actions.md
+++ b/01_STAGING/00_INBOX_DUMP/ATOMIC_NOTES/Task System - High Impact Job Search Daily Actions.md
@@ -1,0 +1,29 @@
+# Task System - High Impact Job Search Daily Actions
+
+Type: Task System
+Tags: #job-search #execution #high-impact
+
+## Core idea
+Prioritize direct outcome-producing actions daily: applications, referrals, technical practice, and public proof-of-work.
+
+## Explanation
+The high-impact list centers on measurable leverage points (targeted applications, networking outreach, technical skill reps, visible project sharing).
+
+## Use case
+Use as daily default checklist before any organizational/cleanup tasks.
+
+## Links
+- Connects to [[Task System - Supporting Operations and Organization]]
+- Connects to [[Workflow - Micro Execution OS for Deep Work Blocks]]
+
+## Questions
+- Which 2-3 actions are minimum viable daily non-negotiables?
+- What metric defines “targeted” in job applications?
+
+## Extracted tasks
+- Apply for 10 targeted jobs and log them.
+- Message 5 LinkedIn contacts for referrals.
+- Do 1 LeetCode end-to-end.
+- Process 1 system design video with trade-off notes.
+- Complete 1 module + small code demo.
+- Post latest GitHub project on LinkedIn.

--- a/01_STAGING/00_INBOX_DUMP/ATOMIC_NOTES/Task System - Supporting Operations and Organization.md
+++ b/01_STAGING/00_INBOX_DUMP/ATOMIC_NOTES/Task System - Supporting Operations and Organization.md
@@ -1,0 +1,25 @@
+# Task System - Supporting Operations and Organization
+
+Type: Support System
+Tags: #operations #organization #maintenance
+
+## Core idea
+Use low-impact tasks to maintain infrastructure, but keep them subordinate to high-impact execution work.
+
+## Explanation
+Items like Notion cleanup, folder organization, and vault restructuring are useful enablers but can become avoidance if not bounded.
+
+## Use case
+Schedule in protected low-energy blocks or after completion of high-impact daily quota.
+
+## Links
+- Connects to [[Task System - High Impact Job Search Daily Actions]]
+- Overlaps with [[Decision - Distraction Capture Instead of Distraction Obedience]]
+
+## Questions
+- What weekly time cap should be set for support tasks?
+- Which support tasks can be automated or templated?
+
+## Model layer (relevant)
+- Systems: distinguish throughput drivers from maintenance overhead.
+- Decision: priority ladder prevents optimization-before-output.

--- a/01_STAGING/00_INBOX_DUMP/ATOMIC_NOTES/Workflow - Micro Execution OS for Deep Work Blocks.md
+++ b/01_STAGING/00_INBOX_DUMP/ATOMIC_NOTES/Workflow - Micro Execution OS for Deep Work Blocks.md
@@ -1,0 +1,27 @@
+# Workflow - Micro Execution OS for Deep Work Blocks
+
+Type: Workflow
+Tags: #deep-work #workflow #execution-system
+
+## Core idea
+Convert large tasks into 20–30 minute microtasks, execute one microtask per focused block, then log reality and iterate.
+
+## Explanation
+The workflow integrates planning, execution timer, break cycle, and feedback correction. Tools (Super Productivity + Forest) support but do not replace the protocol.
+
+## Use case
+Apply to any cognitively heavy goal (LeetCode, job applications, interview prep, project work).
+
+## Links
+- Connects to [[Decision - Sequential Listening Rule]] (single-thread focus)
+- Connects to [[Task System - High Impact Job Search Daily Actions]]
+- Connects to [[Decision - Distraction Capture Instead of Distraction Obedience]]
+
+## Questions
+- What criteria decide whether a microtask was sized correctly?
+- What is the daily/weekly cadence for protocol review?
+
+## Model layer (relevant)
+- Behavioral: implementation intention + friction reduction.
+- RL: short-loop feedback updates task sizing policy.
+- Systems: closed-loop control (plan → execute → log → adjust).

--- a/01_STAGING/PROCESSING_AUDIT.md
+++ b/01_STAGING/PROCESSING_AUDIT.md
@@ -1,0 +1,151 @@
+# Obsidian Vault Processing Audit
+
+_Date audited: 2026-05-02 (UTC)_
+
+## Coverage summary
+Scope audited:
+- `00_INBOX_DUMP/`
+- `01_STAGING/00_INBOX_DUMP/`
+- `01_STAGING/01_LONG_FORM/`
+- all nested subfolders
+
+### High-level totals (in audited scope)
+- Total files: **248**
+- Processed into atomic notes: **12**
+- Unprocessed (raw/staging/reference/templates/projects): **236**
+- Empty/placeholder files: **11**
+- Exact-duplicate content groups: **2 groups**
+
+> Processing status definition used in this audit:
+> - **Processed** = files in `01_STAGING/00_INBOX_DUMP/ATOMIC_NOTES/` that are Obsidian-ready atomic notes.
+> - **Unprocessed** = everything else (raw inbox, staging lists/text, long-form notes, study material, PDFs/DOCX/ZIP).
+
+---
+
+## Folder-by-folder status
+
+| Folder | Total files | Processed files | Unprocessed files | Empty / placeholders | Notes |
+|---|---:|---:|---:|---:|---|
+| `00_INBOX_DUMP/` | 6 | 0 | 6 | 3 | Raw inbox sources; includes small plaintext scratch files. |
+| `01_STAGING/00_INBOX_DUMP/ATOMIC_NOTES/` | 12 | 12 | 0 | 0 | Fully processed atomic-note output set (current processed corpus). |
+| `01_STAGING/00_INBOX_DUMP/JOURNAL/` | 8 | 0 | 8 | 0 | Preserve as journal/templates; not atomicized yet. |
+| `01_STAGING/00_INBOX_DUMP/LISTS/` | 47 | 0 | 47 | 3 | Large backlog; multiple overlap/duplication candidates. |
+| `01_STAGING/00_INBOX_DUMP/TEMPLATES/` | 1 | 0 | 1 | 0 | Template asset; preserve as canonical template. |
+| `01_STAGING/00_INBOX_DUMP/TEXT/` | 10 | 0 | 10 | 0 | Raw text fragments; needs triage + decomposition. |
+| `01_STAGING/01_LONG_FORM/` | 1 | 0 | 1 | 0 | Contains `STUDY_MATERIAL.zip` archive. |
+| `01_STAGING/01_LONG_FORM/NOTES/` | 51 | 0 | 51 | 3 | Long-form note library with likely overlap variants. |
+| `01_STAGING/01_LONG_FORM/STUDY_MATERIAL/` | 31 | 0 | 31 | 1 | Mixed markdown + binaries (pdf/docx). |
+| `01_STAGING/01_LONG_FORM/STUDY_MATERIAL/Amazon/` | 29 | 0 | 29 | 1 | Project/reference packet; includes markdown and interview docs. |
+| `01_STAGING/01_LONG_FORM/STUDY_MATERIAL/Amazon/pdfs/` | 15 | 0 | 15 | 0 | Binary-heavy reference subset. |
+| `01_STAGING/01_LONG_FORM/STUDY_MATERIAL/Doordash/` | 5 | 0 | 5 | 0 | Project/reference packet. |
+| `01_STAGING/01_LONG_FORM/SYSTEMS/` | 32 | 0 | 32 | 0 | Systems/process library; many candidates for atomic decomposition. |
+
+---
+
+## File classification table
+
+| Class | Description | Current locations | Count (approx) | Preserve as |
+|---|---|---|---:|---|
+| Atomic notes (processed) | Obsidian-ready, structured atomic units | `01_STAGING/00_INBOX_DUMP/ATOMIC_NOTES/` | 12 | **Atomic notes** |
+| Raw inbox capture | Minimal/rough captures, unnormalized | `00_INBOX_DUMP/`, `01_STAGING/00_INBOX_DUMP/TEXT/` | 16 | **Raw capture / backlog** |
+| Lists and resource collections | Curated or semi-curated lists | `01_STAGING/00_INBOX_DUMP/LISTS/` | 47 | **Reference or project notes** |
+| Journal/review templates & personal reflections | Review cadence + identity notes | `01_STAGING/00_INBOX_DUMP/JOURNAL/` | 8 | **Journal notes** |
+| Templates | Reusable note structures | `01_STAGING/00_INBOX_DUMP/TEMPLATES/`, long-form templates | 3+ | **Templates** |
+| Long-form conceptual notes | Essays, guides, hubs, MoCs | `01_STAGING/01_LONG_FORM/NOTES/`, `SYSTEMS/` | 83 | **Long-form reference / model / systems notes** |
+| Project-specific study packs | Interview/company prep artifacts | `01_STAGING/01_LONG_FORM/STUDY_MATERIAL/` (+ `Amazon`, `Doordash`) | 80 | **Project/reference notes** |
+| Binary reference assets | PDFs, DOCX, ZIP | `01_STAGING/01_LONG_FORM/**` | 40+ | **Reference attachments** |
+
+---
+
+## Empty/placeholder files
+
+### Confirmed empty or whitespace-only
+- `00_INBOX_DUMP/.gitkeep`
+- `00_INBOX_DUMP/job sites`
+- `00_INBOX_DUMP/sticknote_password`
+- `01_STAGING/00_INBOX_DUMP/LISTS/Behavioral_Interview_Links.md`
+- `01_STAGING/00_INBOX_DUMP/LISTS/Inbox.md`
+- `01_STAGING/00_INBOX_DUMP/LISTS/Resources - CodeCrafters.md.md`
+- `01_STAGING/01_LONG_FORM/NOTES/3. Technical Deep Dives.md`
+- `01_STAGING/01_LONG_FORM/NOTES/Core Philosophy.md`
+- `01_STAGING/01_LONG_FORM/NOTES/Home.md`
+- `01_STAGING/01_LONG_FORM/STUDY_MATERIAL/Recommendation Engine Design.md`
+- `01_STAGING/01_LONG_FORM/STUDY_MATERIAL/Amazon/LPs.md`
+
+---
+
+## Duplicate / near-duplicate candidates
+
+### Exact duplicate content (hash-identical)
+1) **Empty-file group** (all zero-byte/blank):
+- `00_INBOX_DUMP/.gitkeep`
+- `00_INBOX_DUMP/job sites`
+- `01_STAGING/00_INBOX_DUMP/LISTS/Inbox.md`
+- `01_STAGING/00_INBOX_DUMP/LISTS/Behavioral_Interview_Links.md`
+- `01_STAGING/00_INBOX_DUMP/LISTS/Resources - CodeCrafters.md.md`
+- `01_STAGING/01_LONG_FORM/NOTES/3. Technical Deep Dives.md`
+- `01_STAGING/01_LONG_FORM/NOTES/Home.md`
+- `01_STAGING/01_LONG_FORM/NOTES/Core Philosophy.md`
+- `01_STAGING/01_LONG_FORM/STUDY_MATERIAL/Recommendation Engine Design.md`
+- `01_STAGING/01_LONG_FORM/STUDY_MATERIAL/Amazon/LPs.md`
+
+2) **Binary duplicate**:
+- `01_STAGING/01_LONG_FORM/STUDY_MATERIAL/Amazon/Medium - Behavioral Interview Questions.pdf`
+- `01_STAGING/01_LONG_FORM/STUDY_MATERIAL/Amazon/pdfs/Medium - Behavioral Interview Questions.pdf`
+
+### Near-duplicate filename/topic candidates (manual review needed)
+- `Books.md` vs `Booksss.md` vs `Books - Progress.md`
+- `Resources - Websites.md` vs `Resources - Websitesss.md`
+- `Flow State.md` vs `Flow_State.md`
+- `How to Create a Routine.md` appears in both `NOTES/` context and `SYSTEMS/` (and prefixed variant `1. How to Create a Routine.md`)
+- `K Step for Flow.md` vs `K-Step Guide to Flow.md`
+- `Technical Deep Dives.md` vs `3. Technical Deep Dives.md`
+- `Character Study - Kangiten.md` vs `Character Study - Kangitenn.md`
+- `Character Study - Count Alexander Ilyich Rostov.md` vs `Character Study - Count Ilyich Rostov.md`
+
+---
+
+## Unprocessed backlog
+
+### Backlog by likely processing mode
+1. **Atomic extraction candidates (highest value, markdown, action-oriented):**
+   - `01_STAGING/00_INBOX_DUMP/LISTS/*.md`
+   - `01_STAGING/00_INBOX_DUMP/TEXT/*.md`
+2. **System/model decomposition candidates:**
+   - `01_STAGING/01_LONG_FORM/SYSTEMS/*.md`
+   - selected `01_STAGING/01_LONG_FORM/NOTES/*.md`
+3. **Project/reference packet normalization (company-specific):**
+   - `01_STAGING/01_LONG_FORM/STUDY_MATERIAL/Amazon/*.md`
+   - `01_STAGING/01_LONG_FORM/STUDY_MATERIAL/Doordash/*.md`
+4. **Attachment indexing only (not full decomposition first pass):**
+   - PDFs / DOCX / ZIP under `01_STAGING/01_LONG_FORM/STUDY_MATERIAL/**`
+
+---
+
+## Recommended next processing order
+
+1. **Batch 2A: `01_STAGING/00_INBOX_DUMP/LISTS/` (priority)**
+   - Convert list-style notes into atomic decisions/tasks/resources.
+   - Resolve duplicates and typo-variants into canonical note IDs (without deleting originals yet).
+
+2. **Batch 2B: `01_STAGING/00_INBOX_DUMP/TEXT/`**
+   - Triage fragments (`Untitled*`, single-letter files) into either atomic notes or archive/open-loop notes.
+
+3. **Batch 3: `01_STAGING/01_LONG_FORM/SYSTEMS/`**
+   - Decompose process frameworks into reusable models, checklists, and protocols.
+
+4. **Batch 4: `01_STAGING/01_LONG_FORM/NOTES/`**
+   - Start with MoCs/hubs and obvious near-duplicates, then decompose concept notes.
+
+5. **Batch 5: `01_STAGING/01_LONG_FORM/STUDY_MATERIAL/**`**
+   - Markdown first, then build attachment index notes for binaries (PDF/DOCX/ZIP).
+
+---
+
+## Risks or ambiguities
+
+- **Processed-definition ambiguity:** only `ATOMIC_NOTES/` is clearly processed; some long-form notes may already be semi-structured but not atomic.
+- **Binary-heavy folders:** PDFs/DOCX/ZIP cannot be fully audited semantically without extraction/parsing.
+- **Naming noise:** typo/variant names make canonical linking brittle (`Booksss`, `Websitesss`, `Kangitenn`, etc.).
+- **Empty placeholders:** multiple empty files can create false backlog volume and confusion about intent.
+- **Cross-folder overlap:** similar topics split across `LISTS`, `NOTES`, `SYSTEMS`, and `STUDY_MATERIAL` may require a canonical source-of-truth strategy before merge/reorg.


### PR DESCRIPTION
### Motivation
- Convert raw inbox captures into discrete, actionable atomic notes to improve retrievability and execution.
- Surface decisions, heuristics, plans, workflows, and open loops to reduce cognitive load during weekly processing.
- Provide an audit of the current staging/processing state to prioritize further decomposition and backlog work.

### Description
- Add 12 processed atomic note files under `01_STAGING/00_INBOX_DUMP/ATOMIC_NOTES/`, including decisions (`Decision - Sequential Listening Rule.md`, `Decision - Distraction Capture Instead of Distraction Obedience.md`), heuristics (`Heuristic - Behavior Change Filter for Learning Inputs.md`), workflows (`Workflow - Micro Execution OS for Deep Work Blocks.md`), plans (`Plan - Five Month Audiobook Curriculum.md`), task systems, constraints, and open-loop placeholders. 
- Add `01_STAGING/00_INBOX_DUMP/ATOMIC_NOTES/INDEX.md` to register the new atomic notes and suggested hubs. 
- Add `01_STAGING/PROCESSING_AUDIT.md` containing a vault-wide audit with totals, folder-by-folder status, duplicate detection, backlog categorization, and recommended next processing order. 
- Create several `Open Loop` notes to flag empty placeholders and security/clarification risks for follow-up during inbox processing.

### Testing
- No automated tests were executed for these content-only documentation changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f51953a30883268eed79e4b1e7624c)