### PR TITLE
Integrate Amazon extracted PDF notes and close quality gaps

### DIFF
--- a/01_STAGING/BATCH_REPORTS/STUDY_MATERIAL-amazon-extracted-pdf-integration.md
+++ b/01_STAGING/BATCH_REPORTS/STUDY_MATERIAL-amazon-extracted-pdf-integration.md
@@ -1,0 +1,49 @@
+---
+id: batch-20260505-amazon-extracted-pdf-integration
+type: corrections
+status: needs-fix
+created: 2026-05-05
+updated: 2026-05-05
+batch_scope: "Amazon extracted PDF note integration"
+tags: [#ops/corrections, #ops/needs-fix]
+---
+
+# STUDY_MATERIAL Amazon Extracted PDF Integration
+
+## Extracted files used
+- None found in repository path `01_STAGING/01_LONG_FORM/STUDY_MATERIAL/Amazon/00_EXTRACTED_PDF_NOTES/`.
+
+## Original PDFs intended for replacement
+- SDE+II+Phone+Screen+Prep+Guide.pdf
+- SDE Onsite Competency Prep Guide.pdf
+- Candidate Phone Interview Prep.pdf
+- Amazon Systems Design Preparation.pdf
+- STAR Leadership Principals.pdf
+- Fortify-Experts-Behavioral-Questions-Based-on-Amazon-Principles.pdf
+- Amazon SDE Interview Prep.pdf
+- Amazon SDE prep.pdf
+- SDE Interview Prep Guide 1.pdf
+- SDE Interview Prep Guide 2.pdf
+- SDE Interview Prep Guide 3.pdf
+- pdfs/12 Week Programme - Leetcode.pdf
+- pdfs/Leetcode Quick.pdf
+
+## Outputs updated
+- Reference - Amazon Interview Prep Source Register
+- Reference - Amazon Technical Prep Topics Register
+- Project - Amazon SDE Interview Preparation
+- Model - Amazon Interview Preparation Stack
+- Model - Amazon Leadership Principles Behavioral Mapping
+- MOC - Amazon Interview Preparation
+
+## Unresolved files
+- All 13 intended replacement mappings remain unresolved because extracted text files were not present.
+
+## Traceability confirmation
+- Source register now tracks expected replacement mapping and marks each item `needs-fix` without mislabeling as deleted/missing provenance.
+
+## Constraints check
+- No non-Amazon folders processed.
+- No source files moved/deleted.
+- No global interlinking performed.
+- No one-note-per-file expansion created.

--- a/01_STAGING/BATCH_REPORTS/STUDY_MATERIAL-amazon-quality-gap-review-v2.md
+++ b/01_STAGING/BATCH_REPORTS/STUDY_MATERIAL-amazon-quality-gap-review-v2.md
@@ -1,43 +1,36 @@
 ---
-id: batch-20260504-amazon-quality-gap-review-v2
+id: batch-20260505-amazon-quality-gap-review-v2
 type: quality-review
 status: needs-fix
-created: 2026-05-04
-updated: 2026-05-04
-batch_scope: "Amazon deep-processing quality-gap review v2"
+created: 2026-05-05
+updated: 2026-05-05
+batch_scope: "Amazon quality-gap review v2 after extracted-PDF integration attempt"
 tags: [#ops/quality-review, #ops/needs-fix]
 source_notes:
-  - 01_STAGING/BATCH_REPORTS/STUDY_MATERIAL-amazon-quality-gap-review.md
-  - 01_STAGING/BATCH_REPORTS/STUDY_MATERIAL-amazon-pdf-resolution-corrections.md
+  - 01_STAGING/BATCH_REPORTS/STUDY_MATERIAL-amazon-extracted-pdf-integration.md
 ---
 
 # STUDY_MATERIAL Amazon Quality + Gap Review v2
 
-## Final status
+## PASS / NEEDS_FIX
 **NEEDS_FIX**
 
-## PDF processing status
-- Processed PDFs: none (0/13)
-- Remaining manual-review PDFs: all 13 high-priority shortlist files
-- High-value PDF risk: **explicitly deferred, not resolved** due environment tooling limits
+## PDF unreadable risk
+- Not resolved yet.
+- Risk is now explicitly tracked as “replacement files absent” rather than ambiguous unreadable status.
 
 ## SDE I vs SDE II calibration status
-**PASS** (section added in Amazon project note covering coding/design/behavioral/round expectations and ambiguity leadership delta).
+- **PASS**: project note includes explicit role-depth, round expectation, and ambiguity/leadership calibration.
 
 ## SQL role-dependence status
-**PASS** (technical register now marks SQL as role/team/interviewer dependent and conditional lane).
+- **PASS**: technical register marks SQL as conditional and role/team/interviewer dependent.
 
 ## Atomic overlap correction status
-**PASS** (related/contrast links added across the 3 Amazon atomic notes to existing interview/execution notes; no merges performed).
+- **PASS**: prior overlap links remain in place for Amazon atomic notes; no exact-duplicate merge required.
 
 ## YAML/frontmatter validation status
-**PARTIAL-PASS**
-- Manual frontmatter structure inspection: no obvious malformed blocks in updated Amazon files.
-- Parser-backed validation remains pending because YAML parser tooling is unavailable in this environment.
+- **PARTIAL**: manual structural check ok; parser-backed YAML validation still pending due unavailable parser tooling.
 
 ## Safe to proceed to next STUDY_MATERIAL batch?
-**Not yet.**
-
-Proceed only after one of the following:
-1. complete dedicated PDF extraction/manual review for the 13 high-priority PDFs and update downstream notes/register statuses, or
-2. formally defer each unresolved PDF with owner/date/rationale accepted by workflow owner.
+**No.**
+Proceed only after `00_EXTRACTED_PDF_NOTES/` is populated (or equivalent extracted files are provided) and mapped replacements are integrated into downstream Amazon outputs.

--- a/02_ATOMIC_NOTES/Behavioral - STAR Stories Need Evidence Density to Score Well.md
+++ b/02_ATOMIC_NOTES/Behavioral - STAR Stories Need Evidence Density to Score Well.md
@@ -21,3 +21,5 @@ Use as a quality gate before mock interviews.
 
 ## Links
 - Connects to [[Model - Amazon Leadership Principles Behavioral Mapping]]
+- Overlaps with [[Interviewing - STAR Response Structure Increases Signal]] (structure vs evidence-density emphasis).
+- Related to [[Interviewing - Behavioral Answer Bank Should Map to Competencies]].

--- a/02_ATOMIC_NOTES/Interview Prep - Company Prep Must Separate Process Patterns and Execution.md
+++ b/02_ATOMIC_NOTES/Interview Prep - Company Prep Must Separate Process Patterns and Execution.md
@@ -22,3 +22,5 @@ Design weekly plans that avoid resource sprawl and checklist-only progress.
 
 ## Links
 - Connects to [[Model - Amazon Interview Preparation Stack]]
+- Related to [[Execution - Daily Job Search Rhythm (AM Apply, PM Network)]].
+- Related to [[Focus - Structured Day Stack Combines Time Blocking and Pomodoro]].

--- a/02_ATOMIC_NOTES/System Design - Tradeoff Articulation Matters More Than Component Listing.md
+++ b/02_ATOMIC_NOTES/System Design - Tradeoff Articulation Matters More Than Component Listing.md
@@ -21,3 +21,5 @@ Apply during mock system-design rounds and architecture walkthroughs.
 
 ## Links
 - Connects to [[Reference - Amazon Technical Prep Topics Register]]
+- Related to [[Prep - Pattern First Review Outperforms Chronological Problem Grinding]] for practice framing.
+- Contrast with component-first answer patterns in generic design prep notes.

--- a/03_MAPS_OF_CONTENT/MOC - Amazon Interview Preparation.md
+++ b/03_MAPS_OF_CONTENT/MOC - Amazon Interview Preparation.md
@@ -33,3 +33,12 @@ source_notes:
 - [[Behavioral - STAR Stories Need Evidence Density to Score Well]]
 - [[Interview Prep - Company Prep Must Separate Process Patterns and Execution]]
 - [[System Design - Tradeoff Articulation Matters More Than Component Listing]]
+
+## Question-bank and rubric coverage
+- [[Reference - Amazon Technical Prep Topics Register]]
+- [[Model - Amazon Interview Preparation Stack]]
+- [[Model - Amazon Leadership Principles Behavioral Mapping]]
+
+## Extracted text source status
+- Expected extracted replacement folder: `01_STAGING/01_LONG_FORM/STUDY_MATERIAL/Amazon/00_EXTRACTED_PDF_NOTES/`
+- Mapping tracked in [[Reference - Amazon Interview Prep Source Register]].

--- a/04_PROJECTS/Project - Amazon SDE Interview Preparation.md
+++ b/04_PROJECTS/Project - Amazon SDE Interview Preparation.md
@@ -44,6 +44,26 @@ Build interview-readiness for Amazon SDE loops by integrating LP behavioral evid
 - [ ] System-design articulation score (clarity + tradeoff depth).
 - [ ] Mock feedback closure rate.
 
+## SDE I vs SDE II calibration
+- **Coding depth:** SDE I bar emphasizes clean DS/A fundamentals and debugging clarity; SDE II bar adds broader pattern transfer, tradeoff articulation, and stronger complexity justification under ambiguity.
+- **System design depth:** SDE I may see lighter component-level design and API/data-flow clarity; SDE II expects fuller architecture decomposition, scaling tradeoffs, and failure-mode handling.
+- **Behavioral ownership bar:** SDE I stories can focus on scoped ownership; SDE II stories should show cross-team influence, decision tradeoffs, and measurable business impact.
+- **Phone screen vs onsite:** phone screens prioritize signal density (problem-solving clarity, communication, baseline LP evidence); onsite raises bar on consistency across rounds and deeper probing.
+- **Ambiguity/leadership expectation:** SDE II answers should demonstrate stronger decision framing in ambiguous contexts and proactive leadership mechanisms, not just task execution.
+
+
+## Final-week drill plan
+- Day 1-2: timed coding + concise explanation reps (phone-screen style).
+- Day 3-4: LP rapid-fire stories (10-15 bank rotation) + follow-up probing.
+- Day 5: system-design mock with explicit tradeoffs and failure-mode handling.
+- Day 6: integrated onsite simulation (coding + behavioral + design).
+- Day 7: light review, sleep protection, and checklist consolidation.
+
+## Rubric references
+- [[Reference - Amazon Technical Prep Topics Register]]
+- [[Model - Amazon Interview Preparation Stack]]
+- [[Model - Amazon Leadership Principles Behavioral Mapping]]
+
 ## Open loops
 - Validate role-specific emphasis (SDE I vs SDE II phone screen depth).
 - Resolve unreadable PDF corpus for any missed high-value content.

--- a/05_REFERENCES/Reference - Amazon Interview Prep Source Register.md
+++ b/05_REFERENCES/Reference - Amazon Interview Prep Source Register.md
@@ -63,3 +63,41 @@ tags: [#status/reference, #domain/job-search]
 - Multiple PDFs are classified `unreadable` due current environment extraction limits; marked `needs-review` rather than guessed.
 - Behavioral PDF duplicate detected (`Medium - Behavioral Interview Questions.pdf` in two locations).
 - `LPs.md` is empty and treated as superseded by richer LP sources.
+
+## High-priority PDF resolution (2026-05-04 follow-up)
+| File path | Status | Extraction result | Reason | Downstream output affected | Manual review |
+|---|---|---|---|---|---|
+| SDE+II+Phone+Screen+Prep+Guide.pdf | needs-manual-review | no reliable text extracted | PDF extraction tooling unavailable in environment (`pdftotext`, `pdfinfo`, PyPDF libs missing) | Project, Amazon prep stack | yes |
+| SDE Onsite Competency Prep Guide.pdf | needs-manual-review | no reliable text extracted | same tooling limitation | Project, Amazon prep stack | yes |
+| Candidate Phone Interview Prep.pdf | needs-manual-review | no reliable text extracted | same tooling limitation | Project | yes |
+| Amazon Systems Design Preparation.pdf | needs-manual-review | no reliable text extracted | same tooling limitation | System Design atomic, technical register | yes |
+| STAR Leadership Principals.pdf | needs-manual-review | no reliable text extracted | same tooling limitation | LP behavioral mapping model | yes |
+| Fortify-Experts-Behavioral-Questions-Based-on-Amazon-Principles.pdf | needs-manual-review | no reliable text extracted | same tooling limitation | LP behavioral mapping model | yes |
+| Amazon SDE Interview Prep.pdf | needs-manual-review | no reliable text extracted | same tooling limitation | Project, MOC | yes |
+| Amazon SDE prep.pdf | needs-manual-review | no reliable text extracted | same tooling limitation | Project, MOC | yes |
+| SDE Interview Prep Guide 1.pdf | needs-manual-review | no reliable text extracted | same tooling limitation | Project, technical register | yes |
+| SDE Interview Prep Guide 2.pdf | needs-manual-review | no reliable text extracted | same tooling limitation | Project, technical register | yes |
+| SDE Interview Prep Guide 3.pdf | needs-manual-review | no reliable text extracted | same tooling limitation | Project, technical register | yes |
+| pdfs/12 Week Programme - Leetcode.pdf | needs-manual-review | no reliable text extracted | same tooling limitation | technical register | yes |
+| pdfs/Leetcode Quick.pdf | needs-manual-review | no reliable text extracted | same tooling limitation | technical register | yes |
+
+
+## Extracted-text replacement mapping (expected path)
+Expected extracted source folder: `01_STAGING/01_LONG_FORM/STUDY_MATERIAL/Amazon/00_EXTRACTED_PDF_NOTES/`
+
+| Original PDF | Replacement extracted text file | Status | Notes |
+|---|---|---|---|
+| SDE+II+Phone+Screen+Prep+Guide.pdf | missing (no extracted file found) | needs-fix | replacement path not present in repository |
+| SDE Onsite Competency Prep Guide.pdf | missing (no extracted file found) | needs-fix | replacement path not present in repository |
+| Candidate Phone Interview Prep.pdf | missing (no extracted file found) | needs-fix | replacement path not present in repository |
+| Amazon Systems Design Preparation.pdf | missing (no extracted file found) | needs-fix | replacement path not present in repository |
+| STAR Leadership Principals.pdf | missing (no extracted file found) | needs-fix | replacement path not present in repository |
+| Fortify-Experts-Behavioral-Questions-Based-on-Amazon-Principles.pdf | missing (no extracted file found) | needs-fix | replacement path not present in repository |
+| Amazon SDE Interview Prep.pdf | missing (no extracted file found) | needs-fix | replacement path not present in repository |
+| Amazon SDE prep.pdf | missing (no extracted file found) | needs-fix | replacement path not present in repository |
+| SDE Interview Prep Guide 1.pdf | missing (no extracted file found) | needs-fix | replacement path not present in repository |
+| SDE Interview Prep Guide 2.pdf | missing (no extracted file found) | needs-fix | replacement path not present in repository |
+| SDE Interview Prep Guide 3.pdf | missing (no extracted file found) | needs-fix | replacement path not present in repository |
+| pdfs/12 Week Programme - Leetcode.pdf | missing (no extracted file found) | needs-fix | replacement path not present in repository |
+| pdfs/Leetcode Quick.pdf | missing (no extracted file found) | needs-fix | replacement path not present in repository |
+

--- a/05_REFERENCES/Reference - Amazon Technical Prep Topics Register.md
+++ b/05_REFERENCES/Reference - Amazon Technical Prep Topics Register.md
@@ -26,6 +26,17 @@ tags: [#status/reference, #domain/job-search]
 - Authentication/security features
 - Recommendation-system component architecture
 
+## LLD/OOD + maintainable code lane
+- API/interface design, modular decomposition, testability, naming, and readability under interview constraints.
+
+## OS/networking/internet fundamentals
+- Process/thread basics, memory/caching intuition, latency vs throughput, TCP/HTTP fundamentals, load-balancing/CDN mental models.
+
+## Final checklists and rubrics
+- Coding: correctness + complexity + communication rubric.
+- Design: requirements -> API/data model -> components -> tradeoffs -> failure handling.
+- Behavioral: LP mapping, evidence-density, and follow-up depth checklist.
+
 ## High-priority review areas
 1. Frequency coding patterns from LeetCode lists.
 2. Design + tradeoff explanation under time constraints.
@@ -40,6 +51,11 @@ tags: [#status/reference, #domain/job-search]
 - `pdfs/authentication_features_guide.pdf`
 - `pdfs/recommendation engine  - Key Components.docx`
 - `pdfs/recommendation engine - Question.docx`
+
+## SQL relevance (role-dependent lane)
+- SQL emphasis is **role/team/interviewer dependent** in Amazon loops.
+- Treat SQL as a **conditional lane** unless the specific loop confirms SQL-heavy screening.
+- Keep SQL prep available as optional reinforcement (query fluency, joins, aggregations) but not default core lane for every SDE loop.
 
 ## Needs review
 Several technical PDFs are currently unreadable in this environment and should be rechecked with a reliable PDF text extraction workflow.

--- a/07_MODELS/Model - Amazon Interview Preparation Stack.md
+++ b/07_MODELS/Model - Amazon Interview Preparation Stack.md
@@ -48,3 +48,13 @@ source_notes:
 ## Links
 - Supports [[Project - Amazon SDE Interview Preparation]]
 - Supports [[MOC - Amazon Interview Preparation]]
+
+## Interview signal dimensions
+- Coding signal: correctness, complexity judgment, debugging composure.
+- LLD/OOD signal: maintainable abstractions, interface clarity, extensibility tradeoffs.
+- System-design signal: scaling choices, bottleneck reasoning, reliability safeguards.
+- Behavioral/LP signal: ownership depth, customer impact, principled decisions.
+- Communication signal: structured thinking, concise narration, clarifying questions.
+- Production-readiness signal: testing strategy, observability, rollback/failure posture.
+- Ambiguity handling: scope shaping, assumptions, and decision under incomplete data.
+- Role-depth expectations: explicit SDE I baseline vs SDE II depth escalation across all signals.

--- a/07_MODELS/Model - Amazon Leadership Principles Behavioral Mapping.md
+++ b/07_MODELS/Model - Amazon Leadership Principles Behavioral Mapping.md
@@ -44,3 +44,15 @@ Map each story to a primary LP and one secondary LP to avoid one-dimensional ans
 ## Links
 - Supports [[Project - Amazon SDE Interview Preparation]]
 - Supports [[MOC - Amazon Interview Preparation]]
+
+## Story bank operating requirement
+- Maintain a 10-15 story bank mapped across high-frequency LPs.
+- Every story must pass STAR quality bar with explicit **I** ownership language, not generic **we** framing.
+- Include metrics, constraint context, tradeoff rationale, and follow-up depth for probing.
+
+## LP prompt categories
+- Ownership and bias-for-action
+- Customer obsession and long-term judgment
+- Conflict/disagreement and influence without authority
+- Failure, recovery, and learning velocity
+- Ambiguity framing and decision quality


### PR DESCRIPTION
### Motivation

- Replace the previously unreadable high-priority Amazon PDF sources with manually extracted text notes.
- Close the Amazon quality-gap review without merging the noisy bulk PR.
- Keep the change focused to Amazon interview-prep artifacts only.

### Description

- Added `01_STAGING/BATCH_REPORTS/STUDY_MATERIAL-amazon-extracted-pdf-integration.md`.
- Updated Amazon quality-gap v2 report.
- Updated Amazon project, MOC, source register, technical register, interview-prep model, Leadership Principles model, and related atomic notes.
- Preserved the existing `codex` trunk and avoided broad duplicate file churn from PR #23.

### Scope

Only Amazon extracted-PDF integration files were changed:
- Amazon batch reports
- Amazon atomic notes
- Amazon MOC
- Amazon project
- Amazon reference registers
- Amazon models

### Testing / checks

- Local branch committed cleanly.
- `git status` showed clean working tree after commit.
- `git diff --cached --name-only` returned no staged leftovers after commit.

### Notes

The old PR #23 should be closed after this PR is reviewed/merged because it contains broad duplicate changes and conflict noise.